### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -100,6 +100,8 @@ jobs:
     needs: [version-check]
     name: "Publish PPA 📦️"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
     - name: "Checkout 🥡"
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/10](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `publish-ppa` job. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the job. Based on the job's steps, it appears that only `contents: read` is necessary for operations like `actions/checkout`. If additional permissions are required, they can be added explicitly.

The changes will be made in the `.github/workflows/publish-release.yml` file, specifically within the `publish-ppa` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
