### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build-quickemu.yml
+++ b/.github/workflows/test-build-quickemu.yml
@@ -27,6 +27,8 @@ on:
 jobs:
   test-deb-build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
     - name: "Checkout 🥡"
       uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/5](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/5)

To fix the issue, we will add an explicit `permissions` block to the `test-deb-build` job. Since this job only needs to read the repository contents (e.g., to build and test `.deb` packages), we will set `contents: read` as the minimal required permission. This ensures that the job does not inherit unnecessary `write` permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
