### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flake-updater.yml
+++ b/.github/workflows/flake-updater.yml
@@ -9,6 +9,9 @@ jobs:
   lock-updater:
     name: Flake Lock Updater
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/3](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the workflow. Based on the actions used in the workflow, the minimal required permissions are likely `contents: read` and `pull-requests: write`. The `contents: read` permission allows the workflow to read repository contents, and `pull-requests: write` is needed to create or update pull requests, as indicated by the `pr-title` input in the `DeterminateSystems/update-flake-lock` action.

The `permissions` block will be added at the job level (`lock-updater`) to limit its scope to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
