### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/flake-checker.yml
+++ b/.github/workflows/flake-checker.yml
@@ -8,6 +8,9 @@ on:
     - cron: '42 0 * * 6'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   flake-checker:
     name: Flake Checker


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/2](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow appears to perform read-only operations (e.g., checking flakes), we will set `contents: read` as the permission. This ensures that the workflow has only the necessary permissions and no unintended write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
