### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -1,4 +1,6 @@
 name: "Lint Shellcheck 🐚"
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/1](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to restrict permissions to the minimum required. Since the workflow only checks out the repository and runs a linting tool, it likely only needs `contents: read` permissions. This ensures the workflow cannot perform any write operations or access unnecessary resources.

The `permissions` block will be added directly below the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
