### PR TITLE
Potential fix for code scanning alert no. 226: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -48,6 +48,8 @@ jobs:
     needs: [draft-release]
     name: "Build Release 👨‍🔧"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v5
     - name: Build and Upload .deb


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/226](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/226)

To fix the problem, add an explicit `permissions` block to the `build-release` job in `.github/workflows/publish-release.yml`. The minimal required permission for uploading release assets is `contents: write`. This change should be made directly under the `runs-on` key for the `build-release` job (after line 50), matching the style used in the `publish-release` and `publish-flakehub` jobs. No other changes are necessary, and this will not affect the existing functionality of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
