### PR TITLE
Potential fix for code scanning alert no. 224: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,6 +15,8 @@ jobs:
   version-check:
     name: "Check versions ⚖️"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/224](https://github.com/Git-Hub-Chris/Quickemu/security/code-scanning/224)

To fix the problem, add a `permissions` block to the `version-check` job in `.github/workflows/publish-release.yml`. The minimal required permission for this job is `contents: read`, which allows the job to read repository contents but not modify them. This change should be made directly under the `version-check` job definition, after the `runs-on` key and before the `steps` key. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
